### PR TITLE
Added namespace clone for property updates

### DIFF
--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -240,11 +240,13 @@ func (m *Mesos) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, er
 						continue
 					}
 					// substituting "framework" wildcard with particular framework id
-					requested[3].Value = exec.Framework
+          ns1 := make([]core.NamespaceElement, len(requested))
+          copy (ns1, requested)
+					ns1[3].Value = exec.Framework
 					// substituting "executor" wildcard with particular executor id
-					requested[4].Value = exec.ID
+					ns1[4].Value = exec.ID
 					// TODO(roger): units
-					metrics = append(metrics, *plugin.NewMetricType(requested, now, tags, "", val))
+					metrics = append(metrics, *plugin.NewMetricType(ns1, now, tags, "", val))
 
 				}
 			} else {


### PR DESCRIPTION
When host has multiple executors running the current code cannot distinguish between them. Consequently multiple metrics are submitted in same time interval, which are in fact from different executors. Addition of namespace clone gets around this.