### PR TITLE
#26 - sending framework name from masters, fixed: #31, #32, #33, #37

### DIFF
--- a/mesos/master/master.go
+++ b/mesos/master/master.go
@@ -36,6 +36,8 @@ type Framework struct {
 	OfferedResources *Resources `json:"offered_resources"`
 	Resources        *Resources `json:"resources"`
 	UsedResources    *Resources `json:"used_resources"`
+	Name             string     `json:"name"`
+	Active           bool       `json:"active"`
 }
 
 type Resources struct {


### PR DESCRIPTION
as for #26 - I added field to capture framework name. At least from masters.
#31 - coding bug, cloning dynamic namespace now
#32 - changed naming. For masters frameworks is prefixed with 'framework'. For agent tasks - prefix: 'task'
#33 - I added special case for two possible dynamic (not tested).
#37 - coding bug, cloning dynamic namespace now