### PR TITLE
New plugin api, new ideas

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,17 +17,16 @@ limitations under the License.
 package main
 
 import (
-	"os"
-
 	"github.com/intelsdi-x/snap-plugin-collector-mesos/mesos"
-	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
 )
 
 // plugin bootstrap
 func main() {
-	plugin.Start(
-		mesos.Meta(),
-		mesos.NewMesosCollector(),
-		os.Args[1],
+	mesosPlugin := mesos.NewMesosCollector()
+	plugin.StartCollector(
+		mesosPlugin,
+		mesos.PluginName,
+		mesos.PluginVersion,
 	)
 }

--- a/mesos/agent/agent.go
+++ b/mesos/agent/agent.go
@@ -17,27 +17,21 @@ limitations under the License.
 package agent
 
 import (
-	"fmt"
-	"regexp"
-	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap-plugin-collector-mesos/mesos/client"
-	"github.com/intelsdi-x/snap-plugin-collector-mesos/mesos/mesos_pb2"
-	"github.com/intelsdi-x/snap-plugin-utilities/ns"
-	"github.com/intelsdi-x/snap-plugin-utilities/str"
 )
 
 // The "/monitor/statistics" endpoint returns an array of JSON objects. Its top-level structure isn't defined by a
 // protobuf, but the "statistics" object (and everything under it) is. For the actual Mesos implementation, see
 // https://github.com/apache/mesos/blob/0.28.1/src/slave/monitor.cpp#L130-L148
 type Executor struct {
-	ID         string                        `json:"executor_id"`
-	Name       string                        `json:"executor_name"`
-	Source     string                        `json:"source"`
-	Framework  string                        `json:"framework_id"`
-	Statistics *mesos_pb2.ResourceStatistics `json:"statistics"`
+	ID         string                 `json:"executor_id"`
+	Name       string                 `json:"executor_name"`
+	Source     string                 `json:"source"`
+	Framework  string                 `json:"framework_id"`
+	Statistics map[string]interface{} `json:"statistics"`
 }
 
 // The "/slave(1)/flags" endpoint on a Mesos agent returns an object that contains a single object "flags".
@@ -96,80 +90,4 @@ func GetMonitoringStatistics(host string) ([]Executor, error) {
 	}
 
 	return executors, nil
-}
-
-// Recursively traverse the Executor struct, building "/"-delimited strings that resemble snap metric types. If a given
-// feature is not enabled on a Mesos agent (e.g. the network isolator), then those metrics will be removed from the
-// metric types returned by this function.
-func GetMonitoringStatisticsMetricTypes(host string) ([]string, error) {
-	log.Debug("Getting monitoring statistics metrics type from host ", host)
-	// TODO(roger): supporting NetTrafficControlStatistics means adding another dynamic metric to the plugin.
-	// When we're ready to do this, remove ns.InspectEmptyContainers(ns.AlwaysFalse) so this defaults to true.
-	namespaces := []string{}
-	err := ns.FromCompositeObject(
-		&mesos_pb2.ResourceStatistics{}, "", &namespaces, ns.InspectEmptyContainers(ns.AlwaysFalse))
-	if err != nil {
-		log.Error(err)
-		return nil, err
-	}
-
-	// Avoid returning a metric type that is impossible to collect on this system
-	flags, err := GetFlags(host)
-	if err != nil {
-		log.Error(err)
-		return nil, err
-	}
-
-	// Isolators are defined using a comma-separated string passed to the "--isolation" flag on the Mesos agent.
-	// See https://github.com/apache/mesos/blob/0.28.1/src/slave/containerizer/mesos/containerizer.cpp#L196-L223
-	isolators := strings.Split(flags["isolation"], ",")
-
-	if str.Contains(isolators, "cgroups/perf_event") {
-		log.Debug("Isolator cgroups/perf_event is enabled on host ", host)
-		// Expects a perf event from the output of `perf list`. Mesos then normalizes the event name. See
-		// https://github.com/apache/mesos/blob/0.28.1/src/linux/perf.cpp#L65-L71
-		namespaces = deleteFromSlice(namespaces, "^perf/.*")
-		var normalizedPerfEvents []string
-		perfEvents := strings.Split(flags["perf_events"], ",")
-
-		for _, event := range perfEvents {
-			log.Debug("Adding perf event ", event, " to metrics catalog")
-			event = fmt.Sprintf("perf/%s", normalizePerfEventName(event))
-			normalizedPerfEvents = append(normalizedPerfEvents, event)
-		}
-		namespaces = append(namespaces, normalizedPerfEvents...)
-	} else {
-		log.Debug("Isolator cgroups/perf_event is not enabled on host ", host)
-		namespaces = deleteFromSlice(namespaces, "^perf.*")
-	}
-
-	if !str.Contains(isolators, "posix/disk") {
-		log.Debug("Isolator posix/disk is not enabled on host ", host)
-		namespaces = deleteFromSlice(namespaces, "^disk_.*")
-	}
-
-	if !str.Contains(isolators, "network/port_mapping") {
-		log.Debug("Isolator network/port_mapping is not enabled on host ", host)
-		namespaces = deleteFromSlice(namespaces, "^net_.*")
-	}
-
-	return namespaces, nil
-}
-
-// Normalizes a perf event, based on https://github.com/apache/mesos/blob/0.28.1/src/linux/perf.cpp#L65-L71
-func normalizePerfEventName(s string) string {
-	normalized := strings.ToLower(s)
-	return strings.Replace(normalized, "-", "_", -1)
-}
-
-// Delete a given string from a slice, without returning a new slice. Regex is allowed (e.g. '^perf/.*').
-func deleteFromSlice(a []string, s string) []string {
-	for i := 0; i < len(a); i++ {
-		matched, _ := regexp.MatchString(s, a[i])
-		if matched {
-			a = append(a[:i], a[i+1:]...)
-			i--
-		}
-	}
-	return a
 }

--- a/mesos/master/master.go
+++ b/mesos/master/master.go
@@ -36,6 +36,8 @@ type Framework struct {
 	OfferedResources *Resources `json:"offered_resources"`
 	Resources        *Resources `json:"resources"`
 	UsedResources    *Resources `json:"used_resources"`
+	Name             string     `json:"name"`
+	Active           bool       `json:"active"`
 }
 
 type Resources struct {

--- a/mesos/master/master.go
+++ b/mesos/master/master.go
@@ -24,7 +24,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap-plugin-collector-mesos/mesos/client"
-	"github.com/intelsdi-x/snap-plugin-utilities/ns"
+	//	"github.com/intelsdi-x/snap-plugin-utilities/ns"
 )
 
 type Frameworks struct {
@@ -86,7 +86,7 @@ func GetMetricsSnapshot(host string) (map[string]float64, error) {
 func IsLeader(host string) (bool, error) {
 	log.Debug("Determining if host ", host, " is currently the leader")
 	req, err := http.NewRequest("HEAD", "http://"+host+"/redirect", nil)
-	if err != nil {
+	if err != nil || req == nil {
 		e := fmt.Errorf("request error: %s", err)
 		log.Error(e)
 		return false, e
@@ -94,7 +94,9 @@ func IsLeader(host string) (bool, error) {
 
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {
-		if resp.StatusCode == 307 {
+		if resp == nil {
+			return false, err
+		} else if resp.StatusCode == 307 {
 			log.Debug("Got expected response HTTP 307")
 		} else if resp.StatusCode != 307 {
 			e := fmt.Errorf("error: expected HTTP 307, got %d", resp.StatusCode)

--- a/mesos/master/master.go
+++ b/mesos/master/master.go
@@ -44,24 +44,7 @@ type Resources struct {
 	CPUs float64 `json:"cpus"`
 	Disk float64 `json:"disk"`
 	Mem  float64 `json:"mem"`
-}
-
-// Recursively traverse the Frameworks struct, building "/"-delimited strings that resemble snap metric types.
-func GetFrameworksMetricTypes() ([]string, error) {
-	log.Debug("Getting frameworks metric types from protobuf (mesos_pb2)")
-	namespaces := []string{}
-	if err := ns.FromCompositeObject(Framework{}, "", &namespaces); err != nil {
-		log.Error(err)
-		return nil, err
-	}
-	for i := 0; i < len(namespaces); i++ {
-		if namespaces[i] == "id" {
-			namespaces = append(namespaces[:i], namespaces[i+1:]...)
-			break
-		}
-	}
-	return namespaces, nil
-
+	GPUs float64 `json:"gpus"`
 }
 
 // Get metrics from the '/master/frameworks' endpoint on the master. This endpoint returns JSON about the overall
@@ -70,7 +53,7 @@ func GetFrameworks(host string) ([]*Framework, error) {
 	log.Debug("Getting active frameworks resource utilization from master ", host)
 	var frameworks Frameworks
 
-	c := client.NewClient(host, "/master/frameworks", time.Duration(10))
+	c := client.NewClient(host, "/frameworks", time.Duration(10))
 	if err := c.Fetch(&frameworks); err != nil {
 		log.Error(err)
 		return nil, err
@@ -102,7 +85,7 @@ func GetMetricsSnapshot(host string) (map[string]float64, error) {
 // Determine if a given host is currently the leader, based on the location provided by the '/master/redirect' endpoint.
 func IsLeader(host string) (bool, error) {
 	log.Debug("Determining if host ", host, " is currently the leader")
-	req, err := http.NewRequest("HEAD", "http://"+host+"/master/redirect", nil)
+	req, err := http.NewRequest("HEAD", "http://"+host+"/redirect", nil)
 	if err != nil {
 		e := fmt.Errorf("request error: %s", err)
 		log.Error(e)

--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -17,18 +17,14 @@ limitations under the License.
 package mesos
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
+	"encoding/json"
 	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap-plugin-collector-mesos/mesos/agent"
 	"github.com/intelsdi-x/snap-plugin-collector-mesos/mesos/master"
-	"github.com/intelsdi-x/snap-plugin-utilities/config"
-	//	"github.com/intelsdi-x/snap-plugin-utilities/ns"
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
-	//	"github.com/intelsdi-x/snap/core"
-	"encoding/json"
 	"reflect"
 )
 
@@ -181,34 +177,13 @@ func (m *Mesos) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error) {
 			if err != nil {
 				log.Warning(err)
 				//return nil, err //TODO silently drop error
-			}
-			executors, err := agent.GetMonitoringStatistics(endpoint)
-			if err != nil {
-				log.Warning(err)
-				//return nil, err //TODO silently drop error
-			}
-			for k, v := range snapshot {
-				ns := plugin.NewNamespace(PluginVendor, PluginName)
-				metric := plugin.Metric{
-					Timestamp: timestamp,
-					Namespace: ns.AddStaticElements(strings.Split(k, "/")...),
-					Config:    item.Config,
-					Data:      v,
-					Tags:      tags,
-					Version:   PluginVersion,
+			} else {
+				executors, err := agent.GetMonitoringStatistics(endpoint)
+				if err != nil {
+					log.Warning(err)
+					//return nil, err //TODO silently drop error
 				}
-
-				metrics = append(metrics, metric)
-			}
-
-			for _, executor := range executors {
-				var tree interface{}
-				var data map[string]interface{}
-				bytes, _ := json.Marshal(executor)
-				json.Unmarshal(bytes, &tree)
-				decodeTree(&tree, &data, "")
-
-				for k, v := range data {
+				for k, v := range snapshot {
 					ns := plugin.NewNamespace(PluginVendor, PluginName)
 					metric := plugin.Metric{
 						Timestamp: timestamp,
@@ -218,7 +193,29 @@ func (m *Mesos) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error) {
 						Tags:      tags,
 						Version:   PluginVersion,
 					}
+
 					metrics = append(metrics, metric)
+				}
+
+				for _, executor := range executors {
+					var tree interface{}
+					var data map[string]interface{}
+					bytes, _ := json.Marshal(executor)
+					json.Unmarshal(bytes, &tree)
+					decodeTree(&tree, &data, "")
+
+					for k, v := range data {
+						ns := plugin.NewNamespace(PluginVendor, PluginName)
+						metric := plugin.Metric{
+							Timestamp: timestamp,
+							Namespace: ns.AddStaticElements(strings.Split(k, "/")...),
+							Config:    item.Config,
+							Data:      v,
+							Tags:      tags,
+							Version:   PluginVersion,
+						}
+						metrics = append(metrics, metric)
+					}
 				}
 			}
 
@@ -226,38 +223,4 @@ func (m *Mesos) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error) {
 	}
 	log.Debug("Collected a total of ", len(metrics), " metrics.")
 	return metrics, nil
-}
-
-func getConfig(cfg interface{}) (map[string]string, error) {
-	items := make(map[string]string)
-	var ok bool
-
-	// Note: although config.GetConfigItems can accept multiple config parameter names, it appears that if
-	// any of those names are missing, GetConfigItems() will `return nil, err`. Since this plugin will work
-	// individually with master or agent (or both), we break this up into two separate lookups and then
-	// test for the existence of the configuration parameter to determine which metric types are available.
-
-	// We expect the value of "master" in the global config to follow the convention "192.168.99.100:5050"
-	master_cfg, master_err := config.GetConfigItem(cfg, "master")
-
-	// We expect the value of "agent" in the global config to follow the convention "192.168.99.100:5051"
-	agent_cfg, agent_err := config.GetConfigItem(cfg, "agent")
-
-	if master_err != nil && agent_err != nil {
-		e := fmt.Errorf("error: no global config specified for 'master' and 'agent'.")
-		log.Error(e)
-		return items, e
-	}
-
-	items["master"], ok = master_cfg.(string)
-	if !ok {
-		log.Warn("No global config specified for 'master', only 'agent' metrics will be collected.")
-	}
-
-	items["agent"], ok = agent_cfg.(string)
-	if !ok {
-		log.Warn("No global config specified for 'agent', only 'master' metrics will be collected.")
-	}
-
-	return items, nil
 }

--- a/mesos/mesos_test.go
+++ b/mesos/mesos_test.go
@@ -31,8 +31,8 @@ import (
 func TestMesosPlugin(t *testing.T) {
 	Convey("Meta should return metadata for the plugin", t, func() {
 		meta := Meta()
-		So(meta.Name, ShouldResemble, pluginName)
-		So(meta.Version, ShouldResemble, pluginVersion)
+		So(meta.Name, ShouldResemble, PluginName)
+		So(meta.Version, ShouldResemble, PluginVersion)
 		So(meta.Type, ShouldResemble, pluginType)
 	})
 


### PR DESCRIPTION
I did cancel my previous pull request as it would require too many patches and workarounds to make it work at all.

This uses new API.
Several additional issues was addressed:
- plugin can be loaded any time (before or after mesos-master/agent)
- no need to trigger plugin reload on master change
- it will give any metrics available at any time (not only on plugin load)
- endpoints are now configurable via TASK rather than global configuration of Snap itself

As I drop all dynamic namespace/static idea, code becomes much simpler. My main goal was to provide something what works in all cases without extra overhead.

This is first version of how I see it. Code needs to remove absolute/not used parts, maybe a bit some optimisation there and here.

If you have a time or wish - try it out. I only tested on local mesos master. Will shortly deploy on infra and will see how it goes. 

As plugin is missing filtering options, I plan to add extra variable in config where people can configure regex, to filter metrics they want or not. We can do either inclusive or exclusive filtering.

This should cancel some issues as well. 

I will be able to test on mesos 1.1.0. If someone can do on older version, would be great.


As for writing tests question - I would be very happy if someone else could do that.