### PR TITLE
Clone namespace to avoid overwriting metric key

### DIFF
--- a/mesos/mesos.go
+++ b/mesos/mesos.go
@@ -189,9 +189,10 @@ func (m *Mesos) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, er
 							continue
 						}
 						// substituting "framework" wildcard with particular framework id
-						requested[3].Value = framework.ID
+						rendered := cloneNamespace(requested)
+						rendered[3].Value = framework.ID
 						// TODO(roger): units
-						metrics = append(metrics, *plugin.NewMetricType(requested, now, tags, "", val))
+						metrics = append(metrics, *plugin.NewMetricType(rendered, now, tags, "", val))
 
 					}
 				} else {
@@ -239,12 +240,13 @@ func (m *Mesos) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, er
 						log.Warn("Attempted to collect metric ", requested.String(), " but it returned nil!")
 						continue
 					}
+					rendered := cloneNamespace(requested)
 					// substituting "framework" wildcard with particular framework id
-					requested[3].Value = exec.Framework
+					rendered[3].Value = exec.Framework
 					// substituting "executor" wildcard with particular executor id
-					requested[4].Value = exec.ID
+					rendered[4].Value = exec.ID
 					// TODO(roger): units
-					metrics = append(metrics, *plugin.NewMetricType(requested, now, tags, "", val))
+					metrics = append(metrics, *plugin.NewMetricType(rendered, now, tags, "", val))
 
 				}
 			} else {
@@ -299,4 +301,11 @@ func getConfig(cfg interface{}) (map[string]string, error) {
 	}
 
 	return items, nil
+}
+
+func cloneNamespace(ns core.Namespace) core.Namespace {
+	nsCopy := make(core.Namespace, len(ns))
+	copy(nsCopy, ns)
+
+	return nsCopy
 }


### PR DESCRIPTION
Namespace is basically a slice and even though it's passed to NewMetricType
function by value, its contents isn't being copied, because slice is just
a reference to a portion of array.
It means that we cannot "reuse" Namspace object in next interation, because
by doing that we effectively overwrite Namspace in all previously created
MetricType objects. As a result all metric values have the same
key - the key of the last executor in case of agent metrics,
and last framework in case of master metrics.

For example, for executor metrics returned by MesosAgent:

taskmanager-00005 / cpus_system_time_secs : 1707.13
spark.a3b17c7f-fad3-11e6-900f-024218394c7c / cpus_system_time_secs : 1207.50
broker-7__02275149-ccaf-47e5-9802-c98323edd110 / cpus_system_time_secs : 20386.00

this plugin generates a list of metrics:

/intel/mesos/agent/11cde1a5-c274-4c85-afbe-cfc350aa90fe-0002/broker-7__02275149-ccaf-47e5-9802-c98323edd110/cpus_system_time_secs: 1707.13
/intel/mesos/agent/11cde1a5-c274-4c85-afbe-cfc350aa90fe-0002/broker-7__02275149-ccaf-47e5-9802-c98323edd110/cpus_system_time_secs: 1207.50
/intel/mesos/agent/11cde1a5-c274-4c85-afbe-cfc350aa90fe-0002/broker-7__02275149-ccaf-47e5-9802-c98323edd110/cpus_system_time_secs: 20386.00

The last framework_id and executor_id wins.

This commit fixes the issue by making a defensive copy before
rendering the metric key.